### PR TITLE
build: build only for web environment

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,7 +16,7 @@ var files = [
   'vendor/cbits/chachapoly/chachapoly.c',
   'vendor/cbits/chachapoly/poly1305.c',
 ]
-var command = `emcc cardano-crypto.c ${files.join(' ')} -o lib.js -Os -s WASM=0 -s EXPORTED_FUNCTIONS='["_malloc", "_free"]' --memory-init-file 0  -s NODEJS_CATCH_EXIT=0`
+var command = `emcc cardano-crypto.c ${files.join(' ')} -o lib.js -Os -s WASM=0 -s EXPORTED_FUNCTIONS='["_malloc", "_free"]' --memory-init-file 0  -s NODEJS_CATCH_EXIT=0 -s ENVIRONMENT=web`
 var child = exec(command, function(err){
   if(err){
     throw err


### PR DESCRIPTION
This removes the problematic Node.js-specific code.
It should work in both web and worker environments actually.